### PR TITLE
Better error messages for custom (valid) license declarations

### DIFF
--- a/helpers/output.js
+++ b/helpers/output.js
@@ -32,6 +32,10 @@ function output(rawJSON, license) {
       errorMessage = `Warning: ${chalk.red('The right to use a private or unpublished package has not been granted.')}`
     }
 
+    if (rawJSON.licenseExpression === 'invalid license') {
+      errorMessage = `Warning: ${chalk.red('License declaration is missing or incorrectly formatted.')}`
+    }
+
     if (rawJSON.licenseExpression.includes('SEE LICENSE IN')) {
       errorChalk = chalk.cyan;
       errorMessage = `Info: ${chalk.cyan('A custom license, or one which hasn’t been assigned an SPDX identifier, is in use.')}`

--- a/helpers/output.js
+++ b/helpers/output.js
@@ -25,14 +25,26 @@ function output(rawJSON, license) {
 
     return successOutput
   } else {
+    let errorMessage = `Error: ${chalk.red(rawJSON.conformance.error)}`;
+    let errorChalk = chalk.red;
+
+    if (rawJSON.licenseExpression === 'UNLICENSED') {
+      errorMessage = `Warning: ${chalk.red('The right to use a private or unpublished package has not been granted.')}`
+    }
+
+    if (rawJSON.licenseExpression.includes('SEE LICENSE IN')) {
+      errorChalk = chalk.cyan;
+      errorMessage = `Info: ${chalk.cyan('A custom license, or one which hasn’t been assigned an SPDX identifier, is in use.')}`
+    }
+
     const errorOutput = archy({
-      label: `License Expression: ${chalk.red(rawJSON.licenseExpression)}`,
+      label: `License Expression: ${errorChalk(rawJSON.licenseExpression)}`,
       nodes: [
-        `There are ${chalk.yellow(rawJSON.occurances)} occurances of ${chalk.red(license)}.`,
+        `There are ${chalk.yellow(rawJSON.occurances)} occurances of ${errorChalk(license)}.`,
         {
           label: `Conformance:`,
           nodes: [
-            `Error: ${chalk.red(rawJSON.conformance.error)}`
+            `${errorMessage}`
           ]
         },
         {


### PR DESCRIPTION
The NPM [docs](https://docs.npmjs.com/files/package.json#license) for `package.json` consider the following license formats as valid:

```
{ "license" : "SEE LICENSE IN <filename>" }
{ "license": "UNLICENSED" }
```

This PR adds support for those license types in the form of custom info/warning messages:

<img width="411" alt="Screen Shot 2019-08-03 at 12 08 15 AM" src="https://user-images.githubusercontent.com/3247106/62407238-d8d93400-b582-11e9-9d5c-45821f0af0aa.png">
<img width="617" alt="Screen Shot 2019-08-02 at 11 33 55 PM" src="https://user-images.githubusercontent.com/3247106/62406721-15566100-b57e-11e9-893d-80f4020b08e8.png">
<img width="669" alt="Screen Shot 2019-08-02 at 11 33 45 PM" src="https://user-images.githubusercontent.com/3247106/62406722-19827e80-b57e-11e9-9200-2a98435a21fe.png">

I'm interested in people's thoughts on this change as a whole (is this a positive change?), and on the colour changes for non-errors.